### PR TITLE
Update opnsense-bootstrap.sh

### DIFF
--- a/bootstrap/opnsense-bootstrap.sh
+++ b/bootstrap/opnsense-bootstrap.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Copyright (c) 2015-2020 Franco Fichtner <franco@opnsense.org>
+# Copyright (c) 2015-2021 Franco Fichtner <franco@opnsense.org>
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -63,7 +63,7 @@ while getopts a:bfin:r:t:vy OPT; do
 		TYPE=${OPTARG}
 		;;
 	v)
-		echo ${RELEASE}
+		echo "${RELEASE}"
 		exit 0
 		;;
 	y)
@@ -76,7 +76,7 @@ while getopts a:bfin:r:t:vy OPT; do
 	esac
 done
 
-shift $((${OPTIND} - 1))
+shift $((OPTIND - 1))
 
 if [ "$(id -u)" != "0" ]; then
 	echo "Must be root." >&2
@@ -108,9 +108,9 @@ echo "will automatically reboot."
 
 if [ -z "${DO_YES}" ]; then
 	echo
-	echo -n "Proceed with this action? [y/N]: "
-
-	read YN
+	echo "Proceed with this action? [y/N]: "
+	
+	read -r YN
 	case ${YN} in
 	[yY])
 		;;
@@ -123,9 +123,9 @@ fi
 if [ -n "${DO_FACTORY}" ]; then
 	if [ -z "${DO_YES}" ]; then
 		echo
-		echo -n "Factory reset mode selected, are you sure? [y/N]: "
+		echo "Factory reset mode selected, are you sure? [y/N]: "
 
-		read YN
+		read -r "YN"
 		case ${YN} in
 		[yY])
 			;;
@@ -139,9 +139,9 @@ fi
 if [ -n "${DO_INSECURE}" ]; then
 	if [ -z "${DO_YES}" ]; then
 		echo
-		echo -n "Insecure mode selected, are you sure? [y/N]: "
+		echo "Insecure mode selected, are you sure? [y/N]: "
 
-		read YN
+		read -r "YN"
 		case ${YN} in
 		[yY])
 			;;
@@ -156,7 +156,7 @@ echo
 
 rm -rf /usr/local/etc/pkg
 
-rm -rf ${WORKDIR}/*
+rm -rf "${WORKDIR:?}"/*
 mkdir -p ${WORKDIR}
 
 export ASSUME_ALWAYS_YES=yes
@@ -192,7 +192,7 @@ if [ -z "${DO_BARE}" ]; then
 fi
 
 make -C ${WORKDIR}/core-${SUBDIR} bootstrap DESTDIR= \
-    CORE_ABI=${DO_ABI#"-a "} CORE_FLAVOUR=${FLAVOUR}
+    CORE_ABI="${DO_ABI#"-a "}" CORE_FLAVOUR="${FLAVOUR}"
 
 if [ -z "${DO_BARE}" ]; then
 	if [ -n "${DO_FACTORY}" ]; then
@@ -200,7 +200,7 @@ if [ -z "${DO_BARE}" ]; then
 	fi
 
 	pkg bootstrap
-	pkg install ${TYPE}
+	pkg install "${TYPE}"
 
 	# beyond this point verify everything
 	unset SSL_NO_VERIFY_PEER


### PR DESCRIPTION
I was trying to use this with GCP's FreeBSD 12.2 image. One thing it still likes to do is strip out **google-cloud-sdk**, and **nano** if that's previously installed. In the meanwhile, I used [shellcheck](https://www.shellcheck.net/) to audit it for potential issues & applied recommended fixes.

One other thing to look at with this: in virtualized environments like GCP, Azure, etc; the IP address for all interfaces, are already assigned, so everything needs to be DHCP. I feel like this script could help fix that ahead of time, but not sure how.

Thanks for making a good product though. Been using it for stuff for years now.