### PR TITLE
update: silence grep

### DIFF
--- a/update/opnsense-update.sh.in
+++ b/update/opnsense-update.sh.in
@@ -197,7 +197,7 @@ if [ "${IDENT}" != "${IDENT#*-}" ]; then
 	DO_DEVICE="-D ${IDENT#*-}"
 fi
 
-if ! grep -qc "${SIG_KEY}\"fingerprints\"" ${ORIGIN}; then
+if ! grep -q "${SIG_KEY}\"fingerprints\"" ${ORIGIN}; then
 	# enable insecure mode if repo is unsigned
 	DO_INSECURE="-i"
 


### PR DESCRIPTION
The -c option is printing on stdout the count of the founded items,
even when the -q option is provided:
$ grep -qc sh security.sh
1

In this if we are checking only the return code. So the amount of
founded items is printed to stdout. Checking an return code should
be sufficient.

This is breakes the version option when opnsense-update is
used:

0
20.7.8

The output is used to build a JSON. For example in firmware/check.sh:
base_to_reboot="$(opnsense-update -v)"

And later is used to build a JSON:
packages_upgraded=$packages_upgraded"\"current_version\":\"$base_to_delete\","

Which ends up with invalid JSON:
         "new_version":"0
20.7.8"

Then the php script (like ./firmware/product.php) can't parse such
invalid JSON.

This seems to be also a bug in FreeBSD so I failed separate bug report
there.

Sponsored by: DynFi