### PR TITLE
Fix obvious typo when using `-d` option with `opnsense-code`

### DIFF
--- a/src/code/opnsense-code.sh
+++ b/src/code/opnsense-code.sh
@@ -45,7 +45,7 @@ while getopts a:d:fns:u OPT; do
 		ACCOUNT=${OPTARG}
 		;;
 	d)
-		ACCOUNT=${OPTARG}
+		DIRECTORY=${OPTARG}
 		;;
 	f)
 		FORCE="-f"


### PR DESCRIPTION
Hey, folks,

while hacking on my vagrant-opnsense project I noticed that the `-d` option to `opnsense-code` plain does not work. Simple mistake, easy fix.

Kind regards,
Patrick