### PR TITLE
opnsense-update: Support unescaped mirror URLs

### DIFF
--- a/src/update/opnsense-update.sh.in
+++ b/src/update/opnsense-update.sh.in
@@ -469,7 +469,7 @@ fi
 
 if [ -n "${DO_MIRRORURL}" ]; then
 	# replace the package repo location
-	sed -i '' '/'"${URL_KEY}"'/s/".*${ABI}/"'"${DO_MIRRORURL#"-m "}"'\/${ABI}/' ${ORIGIN}
+	sed -i '' '/'"${URL_KEY}"'/s|".*${ABI}|"'"${DO_MIRRORURL#"-m "}"'/${ABI}|' ${ORIGIN}
 fi
 
 if [ -n "${DO_MIRRORABI}" ]; then


### PR DESCRIPTION
When running opnsense-update with a custom mirror URL, unescaped slashes (which are part of every URL) will cause the script to fail:

    # opnsense-update -ikr whatever -m "http://example.org/"
    sed: 1: "/^[[:space:]]*url:[[:sp ...": bad flag in substitute command: '/'

This patch fixes this by using pipe ('|') instead of slash ('/') as delimiters in the affected sed command.

Escaped slashes (as in `-m "http:\/\/example.org\/"`) will still work after applying the patch, so this should not break existing automation.