### PR TITLE
survive a failed kernel install and let callers see failed applies

### DIFF
--- a/src/update/opnsense-update.sh.in
+++ b/src/update/opnsense-update.sh.in
@@ -737,6 +737,9 @@ if [ "${DO_KERNEL}" = "-K" ]; then
 	WORKDIR=${PENDINGDIR}
 
 	rm -f "${PENDING_KERNEL}"
+
+	# marker is gone; any failure now is a botched apply
+	FAILURE=2
 elif [ "${DO_BASE}" = "-B" ]; then
 	if [ ! -f "${PENDING_BASE}" ]; then
 		# must error out to prevent reboot
@@ -747,6 +750,9 @@ elif [ "${DO_BASE}" = "-B" ]; then
 	WORKDIR=${PENDINGDIR}
 
 	rm -f "${PENDING_BASE}"
+
+	# marker is gone; any failure now is a botched apply
+	FAILURE=2
 elif [ "${DO_PKGS}" = "-P" ]; then
 	if [ ! -f "${PENDING_PKGS}" ]; then
 		# must error out to prevent reboot
@@ -761,6 +767,9 @@ elif [ "${DO_PKGS}" = "-P" ]; then
 	fi
 
 	rm -f "${PENDING_PKGS}" "${INSECURE_PKGS}"
+
+	# marker is gone; any failure now is a botched apply
+	FAILURE=2
 elif [ -n "${DO_LOCAL}" ]; then
 	WORKDIR=${DO_LOCAL#"-l "}
 fi
@@ -893,7 +902,10 @@ exit_msg()
 		echo "${1}"
 	fi
 
-	exit 1
+	# exits 2 instead when a consumed pending set could not
+	# be applied so that callers can tell a botched apply
+	# apart from "nothing to do"
+	exit ${FAILURE:-1}
 }
 
 fetch_set()
@@ -956,6 +968,18 @@ install_tests()
 	echo " done"
 }
 
+revert_kernel()
+{
+	# a failed install must not leave a stub kernel that the
+	# loader would pick by default on the next boot
+	for DIR in ${KERNELDIR} ${DEBUGDIR}${KERNELDIR}; do
+		if [ -d ${DIR}.old ]; then
+			rm -rf ${DIR}
+			mv ${DIR}.old ${DIR}
+		fi
+	done
+}
+
 install_kernel()
 {
 	echo -n "Installing ${KERNELSET}..."
@@ -975,12 +999,14 @@ install_kernel()
 	done
 
 	if ! tar -C / -xpf ${WORKDIR}/${KERNELSET} --exclude="^.abi_hint"; then
-		exit_msg " failed, tar error ${?}"
+		revert_kernel
+		exit_msg " failed, tar error, previous kernel restored"
 	fi
 
 	if [ -z "${DO_UPGRADE}" ]; then
 		if ! kldxref ${KERNELDIR}; then
-			exit_msg " failed, kldxref error ${?}"
+			revert_kernel
+			exit_msg " failed, kldxref error, previous kernel restored"
 		fi
 	fi
 
@@ -1204,7 +1230,7 @@ if [ -n "${DO_BASE}" -a -z "${DO_UPGRADE}" ]; then
 			# Clean all the pending updates, so that
 			# packages are not upgraded as well.
 			empty_cache
-			exit 1
+			exit ${FAILURE:-1}
 		fi
 	fi
 


### PR DESCRIPTION
`install_kernel()` moves /boot/kernel to kernel.old, then untars the new set
directly into place. If tar dies partway through — disk full, I/O error, bad
media — the function exits, but by then the pending marker has already been eaten
and /boot/kernel is a partial stub. Nothing retries, and the loader will pick that
stub by default on the next boot, so a headless machine ends up stuck at the loader
prompt until someone reaches a console and boots kernel.old by hand. The 05-upgrade
hook in core makes this worse than it sounds, because it reboots the moment any
later stage succeeds (see companion PR opnsense/core#10647).

The fix is to put the old kernel back whenever tar or kldxref fail. I looked at
keeping the pending marker for a retry instead, but that is actively dangerous with
the current layout: a second attempt starts by deleting kernel.old — the only good
kernel left — and then moves the wreckage into its place. Restoring immediately is
the safe shape.

Second change: the deferred apply paths (-K/-B/-P) now exit 2 on failure instead
of 1. Exit 1 stays reserved for "no pending marker", which is what the comment in
those branches already promises ("must error out to prevent reboot"). Until now a
caller literally could not tell that apart from an apply that destroyed something,
and core's boot loop used plain success/failure as its only signal. With this, the
matching core change stops the boot sequence on exit 2 instead of stacking base and
packages on top of a broken kernel. Compatibility works out in both directions: old
core with new update treats any non-zero as before, and new core with old update
keeps seeing exit 1 everywhere, so the loop behaves exactly like today.

The FAILURE=2 flag flips on right after the marker is consumed, and the deferred
paths never call fetch_set (that belongs to the lowercase fetch modes), so every
exit_msg it affects really is a botched apply. The base/kernel version-mismatch
abort in the -B path used a bare exit 1, sidestepping exit_msg; it now honours the
flag too, so the boot hook reports the aborted upgrade instead of finishing the
boot without a word.

Known limitation I left alone on purpose: a pkg-level failure inside install_pkgs
(-P) still falls out with exit 0, because the function swallows the result of the
pkg upgrade run. That's pre-existing behaviour, P is the last stage in the boot
sequence, and by that point kernel and base have already applied and rebooted
cleanly, so there is nothing destructive left to protect. Fixing the reporting
there felt like a separate discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
